### PR TITLE
Fixed docker-compose deployment for PC and MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,28 @@
-version: '3.7'
-services: 
+version: '2.1'
+services:
 
-  mysql:
+  mysql-petclinic:
     image: mysql:5.7
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=
-      - MYSQL_ALLOW_EMPTY_PASSWORD=true
-      - MYSQL_USER=petclinic
-      - MYSQL_PASSWORD=petclinic
+      - MYSQL_ROOT_PASSWORD=petclinic
       - MYSQL_DATABASE=petclinic
     volumes:
       - "./conf.d:/etc/mysql/conf.d:ro"
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 24
 
   petclinic:
      depends_on:
-       - mysql
+       - mysql-petclinic
      image: arey/springboot-petclinic
+     depends_on:
+       mysql-petclinic:
+         condition: service_healthy
      ports:
        - "8080:8080"
      environment:
        - SPRING_PROFILES_ACTIVE=mysql,prod
-      #  - spring.profiles.active=mysql.prod
-       - spring.datasource.url=jdbc:mysql://mysql:3306/petclinic?useUnicode=true
-       - spring.datasource.username=petclinic
-       - spring.datasource.password=petclinic
-       - spring.datasource.initialization-mode=always
-       - spring.datasource.initialization=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
       retries: 24
 
   petclinic:
-     depends_on:
-       - mysql-petclinic
      image: arey/springboot-petclinic
      depends_on:
        mysql-petclinic:


### PR DESCRIPTION
There were 3 problems with PetClinic setup:
1. It created a user with [its SQL queries](https://github.com/spring-petclinic/spring-petclinic-angularjs/blob/master/spring-petclinic-server/src/main/resources/db/mysql/schema.sql) on bootstrap, so it needed root permissions. I've reconfigured the docker-compose file to set a root password and DB name only.
2. There was a race condition of PetClinic and MySQL - PC started before the database and wasn't able to reach the DB. There was no failover and PetClinic never tried to reconnect again. To address this issue, I've created a healthcheck for MySQL container that preceded the start of the PetClinic container. But I had to downgrade the compose file's version because this feature was removed in v3
3. [Default application config](https://github.com/spring-petclinic/spring-petclinic-angularjs/blob/master/spring-petclinic-server/src/main/resources/application-mysql.properties) of Petclinic is connecting to mysql-petclinic host, so I've changed the name of the service in compose file to avoid overriding Spring properties.